### PR TITLE
Fix proibição da criação de setores com mesmo nome

### DIFF
--- a/src/Controllers/SectorController.js
+++ b/src/Controllers/SectorController.js
@@ -36,7 +36,7 @@ const sectorCreate = async (req, res) => {
       updatedAt: moment.utc(moment.tz('America/Sao_Paulo').format('YYYY-MM-DDTHH:mm:ss')).toDate(),
     });
     return res.status(200).json(newSector);
-  } catch(error) {
+  } catch (error) {
     return res.status(400).json({ error: error.code });
   }
 };

--- a/src/Controllers/SectorController.js
+++ b/src/Controllers/SectorController.js
@@ -37,10 +37,7 @@ const sectorCreate = async (req, res) => {
     });
     return res.status(200).json(newSector);
   } catch(error) {
-    if (error.code === 11000) {
-      return res.status(400).json({ duplicated: error.keyValue });
-    }
-    return res.status(400).json({ error: error });
+    return res.status(400).json({ error: error.code });
   }
 };
 

--- a/src/Controllers/SectorController.js
+++ b/src/Controllers/SectorController.js
@@ -28,14 +28,20 @@ const sectorCreate = async (req, res) => {
     return res.status(400).json({ status: validFields });
   }
 
-  const newSector = await Sector.create({
-    name,
-    description,
-    createdAt: moment.utc(moment.tz('America/Sao_Paulo').format('YYYY-MM-DDTHH:mm:ss')).toDate(),
-    updatedAt: moment.utc(moment.tz('America/Sao_Paulo').format('YYYY-MM-DDTHH:mm:ss')).toDate(),
-  });
-
-  return res.status(200).json(newSector);
+  try {
+    const newSector = await Sector.create({
+      name,
+      description,
+      createdAt: moment.utc(moment.tz('America/Sao_Paulo').format('YYYY-MM-DDTHH:mm:ss')).toDate(),
+      updatedAt: moment.utc(moment.tz('America/Sao_Paulo').format('YYYY-MM-DDTHH:mm:ss')).toDate(),
+    });
+    return res.status(200).json(newSector);
+  } catch(error) {
+    if (error.code === 11000) {
+      return res.status(400).json({ duplicated: error.keyValue });
+    }
+    return res.status(400).json({ error: error });
+  }
 };
 
 const sectorUpdate = async (req, res) => {

--- a/src/Models/SectorSchema.js
+++ b/src/Models/SectorSchema.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const sectorSchema = new mongoose.Schema({
   name: {
     type: String,
+    unique: true,
     require: [true],
   },
   description: {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -40,6 +40,13 @@ describe('Sample Test', () => {
     done();
   });
 
+  it('Post duplicated sector', async (done) => {
+    const res = await request(app).post('/sector/create').set('x-access-token', token).send(sector);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 11000 });
+    done();
+  }) 
+
   // sector
   it('Get sector', async (done) => {
     const res = await request(app).get('/sector/').set('x-access-token', token);

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -5,7 +5,7 @@ const jwt = require('jsonwebtoken');
 describe('Sample Test', () => {
   let id;
   const sector = {
-    name: 'enfermagem',
+    name: Math.random().toString(36).substr(2, 5),
     description: 'setor de enfermagem',
   };
 
@@ -18,7 +18,6 @@ describe('Sample Test', () => {
     done();
   });
 
-  // sector/create
   it('Post sector', async (done) => {
     const res = await request(app).post('/sector/create').set('x-access-token', token).send(sector);
     expect(res.statusCode).toBe(200);
@@ -45,16 +44,14 @@ describe('Sample Test', () => {
     expect(res.statusCode).toBe(400);
     expect(res.body).toEqual({ error: 11000 });
     done();
-  }) 
+  });
 
-  // sector
   it('Get sector', async (done) => {
     const res = await request(app).get('/sector/').set('x-access-token', token);
     expect(res.statusCode).toBe(200);
     done();
   });
 
-  // sector/:id
   it('Get id sector', async (done) => {
     const res = await request(app).get(`/sector/${id}`).set('x-access-token', token);
     expect(res.statusCode).toBe(200);
@@ -70,7 +67,6 @@ describe('Sample Test', () => {
     done();
   });
 
-  // sector/update/:id
   it('Update sector', async () => {
     const sector = {
         name: "fisioterapia",
@@ -86,7 +82,6 @@ describe('Sample Test', () => {
     expect(res.body.description).toBe(sector.description);
 });
 
-// Invalido
 it('Update sector error', async () => {
     const sector = {
         name: "",

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -6,7 +6,7 @@ describe('Sample Test', () => {
   let id;
   const sector = {
     name: Math.random().toString(36).substr(2, 5),
-    description: 'setor de enfermagem',
+    description: 'setor teste',
   };
 
   const token = jwt.sign({ name: "Teste", description: "Teste" }, process.env.SECRET, {
@@ -27,6 +27,14 @@ describe('Sample Test', () => {
     done();
   });
 
+  it('Post duplicated sector', async (done) => {
+    const res = await request(app).post('/sector/create').set('x-access-token', token).send(sector);
+    console.log(res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 11000 });
+    done();
+  });
+
   it('Post sector error', async (done) => {
     const errorSector = {
       name: '',
@@ -36,13 +44,6 @@ describe('Sample Test', () => {
     const res = await request(app).post('/sector/create').set('x-access-token', token).send(errorSector);
     expect(res.statusCode).toBe(400);
     expect(res.body.status).toEqual(['invalid name', 'invalid description']);
-    done();
-  });
-
-  it('Post duplicated sector', async (done) => {
-    const res = await request(app).post('/sector/create').set('x-access-token', token).send(sector);
-    expect(res.statusCode).toBe(400);
-    expect(res.body).toEqual({ error: 11000 });
     done();
   });
 
@@ -67,12 +68,11 @@ describe('Sample Test', () => {
     done();
   });
 
-  it('Update sector', async () => {
+  it('Update sector', async (done) => {
     const sector = {
-        name: "fisioterapia",
-        description: "setor de fisioterapia"
+      name: "fisioterapia",
+      description: "setor de fisioterapia"
     };
-
     const res = await request(app)
     .put(`/sector/update/${id}`)
     .set('x-access-token', token)
@@ -80,66 +80,67 @@ describe('Sample Test', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.name).toBe(sector.name);
     expect(res.body.description).toBe(sector.description);
-});
+    done();
+  });
 
-it('Update sector error', async () => {
+  it('Update sector error', async (done) => {
     const sector = {
-        name: "",
-        description: "Jest description"
-    }
-
+      name: "",
+      description: "Jest description"
+    };
     const res = await request(app)
     .put(`/sector/update/${id}`)
     .set('x-access-token', token)
     .send(sector);
     expect(res.statusCode).toBe(400);
     expect(res.body.status).toEqual([ 'invalid name' ]);
-});
+    done();
+  });
 
-it('Update with invalid id', async () => {
+  it('Update with invalid id', async (done) => {
     const sector = {
-        name: "fisioterapia",
-        description: "setor de fisioterapia"
+      name: "fisioterapia",
+      description: "setor de fisioterapia"
     };
-
     const res = await request(app)
     .put(`/sector/update/123abc`)
     .set('x-access-token', token)
-    .send(sector)
+    .send(sector);
     expect(res.statusCode).toBe(400);
-    expect(res.body.err).toBe('invalid id')
-});
+    expect(res.body.err).toBe('invalid id');
+    done();
+  });
 
-it('Update sector without token', async () => {
+  it('Update sector without token', async (done) => {
     const sector = {
-        name: "Jest test",
-        description: "Jest description"
-    }
-
+      name: "Jest test",
+      description: "Jest description"
+    };
     const res = await request(app)
     .put(`/sector/update/${id}`)
     .send(sector);
     expect(res.statusCode).toBe(401);
     expect(res.body).toEqual({ auth: false, message: 'No token was provided' });
-});
+    done();
+  });
 
-it('Update sector with invalid token', async () => {
+  it('Update sector with invalid token', async (done) => {
     const tokenFalho = 'abc123';
     const sector = {
-        name: "Jest test",
-        description: "Jest description"
+      name: "Jest test",
+      description: "Jest description"
     }
-
     const res = await request(app)
     .put(`/sector/update/${id}`)
     .set('x-access-token', tokenFalho)
     .send(sector);
     expect(res.statusCode).toBe(500);
     expect(res.body).toEqual({ auth: false, message: 'It was not possible to authenticate the token.' });
-});
+    done();
+  });
 
-it('Delete sector', async (done) => {
-    const res = await request(app).delete(`/sector/delete/${id}`).set('x-access-token', token)
+  it('Delete sector', async (done) => {
+    const res = await request(app).delete(`/sector/delete/${id}`).set('x-access-token', token);
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({"message":"success"});
     done();

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -27,14 +27,6 @@ describe('Sample Test', () => {
     done();
   });
 
-  it('Post duplicated sector', async (done) => {
-    const res = await request(app).post('/sector/create').set('x-access-token', token).send(sector);
-    console.log(res);
-    expect(res.statusCode).toBe(400);
-    expect(res.body).toEqual({ error: 11000 });
-    done();
-  });
-
   it('Post sector error', async (done) => {
     const errorSector = {
       name: '',


### PR DESCRIPTION
## Descrição

Adicionado campo no schema para proibir setores com nomes duplicados e alterado o retorno em caso de erro.